### PR TITLE
SMC Query predicate panel not updating

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -5309,6 +5309,7 @@ public class QueryDialog extends JPanel {
                 } else if (currentSelection.getObject() instanceof TCTLAbstractStateProperty) {
                     enableOnlyStateButtons();
                 }
+                updateQueryButtonsAccordingToSelection();
             } else {
                 enableOnlyUntimedStateButtons();
                 updateQueryButtonsAccordingToSelection();


### PR DESCRIPTION
Fixed predicate panel on smc queries not updating correctly when selecting a part of a query